### PR TITLE
Skip rollupId 0 in registry, harden L2 entry binding, tighten rollup manager registration

### DIFF
--- a/.claude/commands/run-e2e.md
+++ b/.claude/commands/run-e2e.md
@@ -1,10 +1,13 @@
 ---
-description: Sequentially run all e2e tests against the devnet and summarize results
+description: Run all e2e tests against the devnet and summarize results
 ---
 
 # /run-e2e — Daily e2e test runner (flatten model)
 
-Runs every e2e scenario in `script/e2e/` **sequentially** against the configured devnet and reports pass/fail. Sequential execution is mandatory — the shared deployer nonce makes parallel runs unsafe.
+Runs every e2e scenario in `script/e2e/` and reports pass/fail.
+
+- **Local mode runs in parallel by default** — each scenario gets its own anvil pair on unique ports + chain IDs (so forge `broadcast/<basename>/<chainId>/` dirs and deployer nonces don't collide).
+- **Network mode stays sequential** — the shared on-chain deployer nonce makes parallel runs against a real devnet unsafe.
 
 ## Preconditions
 
@@ -12,10 +15,15 @@ Runs every e2e scenario in `script/e2e/` **sequentially** against the configured
 - Both chains must be producing blocks (not stuck at block 0). A quick `cast block-number` sanity check catches dead RPCs.
 - CREATE2 factory deployed on both chains (use `script/e2e/shared/prepare-network.sh` if uncertain).
 
-## Local vs network mode
+## How to run
 
-- **Local** (default): `bash script/e2e/shared/run-local.sh script/e2e/<scenario>/E2E.s.sol` — spins up two anvils, runs full flow, decodes events.
-- **Network**: `bash script/e2e/shared/run-network.sh script/e2e/<scenario>/E2E.s.sol` — uses the configured devnet, goes through the user-tx-then-batch interception flow.
+- **Local — all scenarios in parallel (default):**
+  `bash script/e2e/shared/run-all-parallel.sh`
+  Forks one `run-local.sh` per scenario with unique `L1_PORT`/`L2_PORT`/`L1_CHAIN_ID`/`L2_CHAIN_ID`. Cap concurrency with `MAX_PARALLEL=N`. Run a subset with positional args: `bash script/e2e/shared/run-all-parallel.sh counter bridge`. Per-scenario logs land in `tmp/e2e-parallel/<scenario>.log`; passes also copied to `tmp/e2e-success/`, failures to `tmp/e2e-failures/`.
+- **Local — single scenario:**
+  `bash script/e2e/shared/run-local.sh script/e2e/<scenario>/E2E.s.sol` — spins up two anvils (defaults: 8545/8546). Override with `L1_PORT`/`L2_PORT`; optionally `L1_CHAIN_ID`/`L2_CHAIN_ID` to override anvil's default chain id (31337) so broadcast dirs don't collide with concurrent runs.
+- **Network (sequential):**
+  `bash script/e2e/shared/run-network.sh script/e2e/<scenario>/E2E.s.sol` — uses the configured devnet, goes through the user-tx-then-batch interception flow. Do not parallelize against a real network — shared deployer nonce will collide.
 
 ## Ordered test list (simplest → most complex)
 

--- a/script/e2e/shared/DeployInfra.s.sol
+++ b/script/e2e/shared/DeployInfra.s.sol
@@ -30,16 +30,8 @@ contract DeployEEZL1 is Script {
         AcceptAllProofSystem ps = new AcceptAllProofSystem();
         EEZ rollups = new EEZ();
 
-        // Burn rollupId 0 (MAINNET) so user rollups start at id 1.
-        {
-            address[] memory psList = new address[](1);
-            psList[0] = address(ps);
-            bytes32[] memory vks = new bytes32[](1);
-            vks[0] = DEFAULT_VK;
-            Rollup burnRollup = new Rollup(address(rollups), msg.sender, 1, psList, vks);
-            rollups.registerRollup(address(burnRollup), bytes32(0));
-        }
-
+        // registerRollup skips id 0 (MAINNET_ROLLUP_ID), so the first registered rollup
+        // lands at id 1.
         // Create L2 manager + register at id 1.
         address[] memory psList2 = new address[](1);
         psList2[0] = address(ps);

--- a/script/e2e/shared/E2EBase.sh
+++ b/script/e2e/shared/E2EBase.sh
@@ -22,12 +22,20 @@ trap cleanup EXIT
 extract() { echo "$1" | grep "$2=" | sed "s/.*$2=//" | awk '{print $1}' || true; }
 
 # ── Start an anvil instance, return PID via variable name ──
-# Usage: start_anvil PORT PID_VAR
+# Usage: start_anvil PORT PID_VAR [CHAIN_ID]
+# If CHAIN_ID is omitted, anvil's default (31337) is used.
 start_anvil() {
     local port="$1"
     local pid_var="$2"
-    echo "Starting anvil (port $port)..."
-    anvil --port "$port" --silent &
+    local chain_id="${3:-}"
+    local chain_arg=()
+    if [[ -n "$chain_id" ]]; then
+        chain_arg=(--chain-id "$chain_id")
+        echo "Starting anvil (port $port, chain-id $chain_id)..."
+    else
+        echo "Starting anvil (port $port)..."
+    fi
+    anvil --port "$port" "${chain_arg[@]}" --silent &
     local pid=$!
     _E2E_PIDS+=("$pid")
     eval "$pid_var=$pid"

--- a/script/e2e/shared/run-all-parallel.sh
+++ b/script/e2e/shared/run-all-parallel.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run every script/e2e/<scenario>/E2E.s.sol via run-local.sh in parallel.
+# Each scenario gets a unique (L1_PORT, L2_PORT, L1_CHAIN_ID, L2_CHAIN_ID) quadruple
+# so anvil instances and forge broadcast/ dirs don't collide.
+#
+# Bad-script caveats:
+#   - No retry, no resource throttling. If your machine can't host 17 anvil pairs,
+#     pass MAX_PARALLEL to cap the worker count.
+#   - Each test gets its own log under tmp/e2e-parallel/<scenario>.log.
+#   - Success logs are kept in tmp/e2e-success/, failures in tmp/e2e-failures/.
+#
+# Usage:
+#   bash script/e2e/shared/run-all-parallel.sh                # all scenarios
+#   MAX_PARALLEL=4 bash script/e2e/shared/run-all-parallel.sh # at most 4 concurrent
+#   bash script/e2e/shared/run-all-parallel.sh counter bridge # subset
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Default ordered list (mirrors .claude/commands/run-e2e.md).
+DEFAULT_TESTS=(
+    counter
+    counterL2
+    bridge
+    helloWorld
+    multi-call-twice
+    multi-call-two-diff
+    nestedCounter
+    nestedCounterL2
+    revertCounter
+    revertCounterL2
+    revertContinue
+    revertContinueL2
+    nestedCallRevert
+    deepNested
+    multi-call-nested
+    multi-call-nestedL2
+    reentrant
+)
+
+if [[ $# -gt 0 ]]; then
+    TESTS=("$@")
+else
+    TESTS=("${DEFAULT_TESTS[@]}")
+fi
+
+MAX_PARALLEL="${MAX_PARALLEL:-${#TESTS[@]}}"
+BASE_PORT="${BASE_PORT:-18545}"      # leave 8545/8546 alone for ad-hoc dev
+BASE_CHAIN_ID="${BASE_CHAIN_ID:-41337}"
+
+mkdir -p tmp/e2e-parallel tmp/e2e-success tmp/e2e-failures
+rm -f tmp/e2e-parallel/*.log tmp/e2e-parallel/*.status
+
+run_one() {
+    local idx="$1" name="$2"
+    local sol="script/e2e/$name/E2E.s.sol"
+    local log="tmp/e2e-parallel/$name.log"
+    local status="tmp/e2e-parallel/$name.status"
+    if [[ ! -f "$sol" ]]; then
+        echo "SKIP" > "$status"
+        echo "  [$name] SKIP (missing $sol)" >&2
+        return 0
+    fi
+    local l1_port=$((BASE_PORT + idx * 2))
+    local l2_port=$((BASE_PORT + idx * 2 + 1))
+    local l1_chain=$((BASE_CHAIN_ID + idx * 2))
+    local l2_chain=$((BASE_CHAIN_ID + idx * 2 + 1))
+    echo "  [$name] starting (L1=$l1_port chain=$l1_chain, L2=$l2_port chain=$l2_chain)" >&2
+    if L1_PORT="$l1_port" L2_PORT="$l2_port" \
+       L1_CHAIN_ID="$l1_chain" L2_CHAIN_ID="$l2_chain" \
+       bash script/e2e/shared/run-local.sh "$sol" > "$log" 2>&1; then
+        echo "PASS" > "$status"
+        cp "$log" "tmp/e2e-success/$name.log"
+        echo "  [$name] PASS" >&2
+    else
+        echo "FAIL" > "$status"
+        cp "$log" "tmp/e2e-failures/$name.log"
+        echo "  [$name] FAIL — see tmp/e2e-failures/$name.log" >&2
+    fi
+}
+
+PIDS=()
+ACTIVE=0
+for i in "${!TESTS[@]}"; do
+    name="${TESTS[$i]}"
+    run_one "$i" "$name" &
+    PIDS+=("$!")
+    ACTIVE=$((ACTIVE + 1))
+    if (( ACTIVE >= MAX_PARALLEL )); then
+        wait -n 2>/dev/null || wait "${PIDS[0]}"
+        ACTIVE=$((ACTIVE - 1))
+    fi
+done
+wait
+
+PASS=0; FAIL=0; SKIP=0
+FAILED_LIST=()
+for name in "${TESTS[@]}"; do
+    s="$(cat "tmp/e2e-parallel/$name.status" 2>/dev/null || echo MISSING)"
+    case "$s" in
+        PASS) PASS=$((PASS+1)) ;;
+        FAIL) FAIL=$((FAIL+1)); FAILED_LIST+=("$name") ;;
+        SKIP) SKIP=$((SKIP+1)) ;;
+        *)    FAIL=$((FAIL+1)); FAILED_LIST+=("$name (no status)") ;;
+    esac
+done
+
+echo ""
+echo "===== RESULT: $PASS passed, $FAIL failed, $SKIP skipped ====="
+for t in "${FAILED_LIST[@]}"; do echo "  FAILED: $t"; done
+[[ $FAIL -eq 0 ]]

--- a/script/e2e/shared/run-local.sh
+++ b/script/e2e/shared/run-local.sh
@@ -18,12 +18,16 @@ L1_PORT="${L1_PORT:-8545}"
 L2_PORT="${L2_PORT:-8546}"
 L1_RPC="http://localhost:$L1_PORT"
 L2_RPC="http://localhost:$L2_PORT"
+# Optional anvil --chain-id overrides. Use unique chain ids per parallel run
+# so forge's broadcast/<basename>/<chain_id>/ directories don't collide.
+L1_CHAIN_ID="${L1_CHAIN_ID:-}"
+L2_CHAIN_ID="${L2_CHAIN_ID:-}"
 export L2_ROLLUP_ID=1
 SYSTEM_ADDRESS="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 
 # 1. Start anvils
-start_anvil "$L1_PORT" L1_PID
-start_anvil "$L2_PORT" L2_PID
+start_anvil "$L1_PORT" L1_PID "$L1_CHAIN_ID"
+start_anvil "$L2_PORT" L2_PID "$L2_CHAIN_ID"
 
 # 2. Deploy infrastructure
 deploy_infra "$L1_RPC" "$PK" "$L2_RPC" "$L2_ROLLUP_ID" "$SYSTEM_ADDRESS"

--- a/script/flash-loan-test/DeployInfra.s.sol
+++ b/script/flash-loan-test/DeployInfra.s.sol
@@ -26,16 +26,8 @@ contract DeployEEZL1 is Script {
         MockProofSystem ps = new MockProofSystem();
         EEZ rollups = new EEZ();
 
-        // Burn rollupId 0 (MAINNET) so user rollups start at id 1.
-        {
-            address[] memory psList = new address[](1);
-            psList[0] = address(ps);
-            bytes32[] memory vks = new bytes32[](1);
-            vks[0] = DEFAULT_VK;
-            Rollup burnRollup = new Rollup(address(rollups), msg.sender, 1, psList, vks);
-            rollups.registerRollup(address(burnRollup), bytes32(0));
-        }
-
+        // registerRollup skips id 0 (MAINNET_ROLLUP_ID), so the first registered rollup
+        // lands at id 1.
         address[] memory psList2 = new address[](1);
         psList2[0] = address(ps);
         bytes32[] memory vks2 = new bytes32[](1);

--- a/src/EEZ.sol
+++ b/src/EEZ.sol
@@ -189,6 +189,24 @@ contract EEZ is EEZBase {
     ///         revert payload (custom error or message) for off-chain debugging.
     event ImmediateEntrySkipped(uint256 indexed transientIdx, bytes revertData);
 
+    /// @notice Emitted the first time `_consumeNestedAction` falls through every routing arm
+    ///         without finding a match — neither an `ExpectedL1ToL2Call` at the current cursor
+    ///         nor a `failed=true` `LookupCall` in the transient table or destination rollup's
+    ///         `lookupQueue`. Surfaces the deferred-no-match path: this call returns empty
+    ///         bytes to the caller (so the caller's `try/catch` observes `success=true` with
+    ///         `""` rather than the expected lookup-call revert), but `_nestedActionNotFound`
+    ///         is latched, and the entry's end-of-entry check will revert `ExecutionNotFound`
+    ///         once `_applyAndExecute` regains control. Detection from off-chain tracing is
+    ///         non-trivial — there's no error frame at the failure site and the subsequent
+    ///         `ExecutionNotFound` revert points at the entry boundary, not the offending
+    ///         reentrant call. The event makes the divergence point legible.
+    event NestedActionNotFound(
+        uint256 indexed entryIndex,
+        bytes32 indexed crossChainCallHash,
+        uint256 callNumber,
+        uint256 lastNestedActionConsumed
+    );
+
     /// @notice Error when proof verification fails
     error InvalidProof();
 
@@ -809,6 +827,13 @@ contract EEZ is EEZBase {
         //    the decode itself reverts the calling frame, which in turn propagates up. The
         //    deferred-revert flag only guarantees the *entry* eventually reverts; it does
         //    NOT guarantee execution reaches the end-of-entry check intact.
+        //
+        //    OBSERVABILITY: this path is hard to detect from a trace alone — the failure point
+        //    here returns success, and the eventual `ExecutionNotFound` surfaces at the entry
+        //    boundary in `_applyAndExecute`, not here. Emit `NestedActionNotFound` so off-chain
+        //    consumers can identify the exact reentrant call whose key didn't match anything
+        //    (prover bug, stale lookup table, or wrong destRid scope).
+        emit NestedActionNotFound(_currentEntryIndex, crossChainCallHash, _currentCallNumber, idx);
         _nestedActionNotFound = true;
         return "";
     }

--- a/src/EEZ.sol
+++ b/src/EEZ.sol
@@ -189,17 +189,9 @@ contract EEZ is EEZBase {
     ///         revert payload (custom error or message) for off-chain debugging.
     event ImmediateEntrySkipped(uint256 indexed transientIdx, bytes revertData);
 
-    /// @notice Emitted the first time `_consumeNestedAction` falls through every routing arm
-    ///         without finding a match — neither an `ExpectedL1ToL2Call` at the current cursor
-    ///         nor a `failed=true` `LookupCall` in the transient table or destination rollup's
-    ///         `lookupQueue`. Surfaces the deferred-no-match path: this call returns empty
-    ///         bytes to the caller (so the caller's `try/catch` observes `success=true` with
-    ///         `""` rather than the expected lookup-call revert), but `_nestedActionNotFound`
-    ///         is latched, and the entry's end-of-entry check will revert `ExecutionNotFound`
-    ///         once `_applyAndExecute` regains control. Detection from off-chain tracing is
-    ///         non-trivial — there's no error frame at the failure site and the subsequent
-    ///         `ExecutionNotFound` revert points at the entry boundary, not the offending
-    ///         reentrant call. The event makes the divergence point legible.
+    /// @notice Emitted on `_consumeNestedAction`'s deferred no-match path. Returns empty
+    ///         bytes; the deferred-revert flag fires `ExecutionNotFound` at the entry boundary.
+    ///         Event exists because the no-match site has no error frame.
     event NestedActionNotFound(
         uint256 indexed entryIndex,
         bytes32 indexed crossChainCallHash,
@@ -827,12 +819,7 @@ contract EEZ is EEZBase {
         //    the decode itself reverts the calling frame, which in turn propagates up. The
         //    deferred-revert flag only guarantees the *entry* eventually reverts; it does
         //    NOT guarantee execution reaches the end-of-entry check intact.
-        //
-        //    OBSERVABILITY: this path is hard to detect from a trace alone — the failure point
-        //    here returns success, and the eventual `ExecutionNotFound` surfaces at the entry
-        //    boundary in `_applyAndExecute`, not here. Emit `NestedActionNotFound` so off-chain
-        //    consumers can identify the exact reentrant call whose key didn't match anything
-        //    (prover bug, stale lookup table, or wrong destRid scope).
+        // Emit so off-chain can locate the no-match site — the eventual revert points at the entry boundary.
         emit NestedActionNotFound(_currentEntryIndex, crossChainCallHash, _currentCallNumber, idx);
         _nestedActionNotFound = true;
         return "";

--- a/src/L2/EEZL2.sol
+++ b/src/L2/EEZL2.sol
@@ -49,9 +49,7 @@ contract EEZL2 is EEZBase {
     /// @notice Error when `msg.value` attached to `executeIncomingCrossChainCall` doesn't match `value`
     error ValueMismatch();
 
-    /// @notice Error when the first entry's `proxyEntryHash` doesn't match the cross-chain
-    ///         call hash computed from the explicit (destination, value, data, sourceAddress,
-    ///         sourceRollup) params passed to `executeIncomingCrossChainCall`
+    /// @notice Entry 0's `proxyEntryHash` doesn't match the hash computed from the explicit params
     error EntryHashMismatch();
 
     /// @notice Emitted when execution entries are loaded into the execution table
@@ -70,11 +68,7 @@ contract EEZL2 is EEZBase {
         uint256 sourceRollup
     );
 
-    /// @param _rollupId The rollup ID this L2 instance belongs to. MUST be non-zero — 0 is
-    ///        reserved as `MAINNET_ROLLUP_ID` on the L1 registry and is used as the
-    ///        `sourceRollupId` sentinel for L1-originated calls in the cross-chain call hash.
-    ///        An L2 deployed with id 0 would produce call hashes indistinguishable from
-    ///        mainnet-originated calls.
+    /// @param _rollupId Non-zero; 0 is reserved as the mainnet sentinel in call hashes.
     /// @param _systemAddress The privileged address allowed to load execution tables
     constructor(uint256 _rollupId, address _systemAddress) {
         if (_rollupId == 0) revert InvalidRollupId();
@@ -211,22 +205,21 @@ contract EEZL2 is EEZBase {
         //    expects (entry index 0, fresh rolling hash, call cursor at 0, nested cursor at 0).
         ExecutionEntry storage entry = executions[0];
 
-        // 4. Bind the inbound call hash to the entry. The (destination, value, data,
-        //    sourceAddress, sourceRollup) tuple was emitted in the event above and folded
-        //    into `crossChainCallHash`; the entry's calls are baked into storage. Without
-        //    this check, SYSTEM_ADDRESS could emit one tuple while `_processNCalls` runs an
-        //    entirely different call sequence, leaving the emitted hash and the actual
-        //    execution divergent. Matches the equivalent check on L1's `_consumeAndExecute`.
+        // 4. Bind the emitted call hash to the entry (mirrors L1 `_consumeAndExecute`).
         if (entry.proxyEntryHash != crossChainCallHash) revert EntryHashMismatch();
 
         // 5. Drive the flat call processor — `entry.L2ToL1Calls[0]` is the inbound call,
         //    delivered via the source proxy by `_processNCalls`
         _processNCalls(entry.callCount);
 
-        // 5. Verify invariants (mirrors `_consumeAndExecute`'s post-checks)
+        // 6. Verify invariants (mirrors `_consumeAndExecute`'s post-checks)
         if (_rollingHash != entry.rollingHash) revert RollingHashMismatch();
         if (_currentCallNumber != entry.L2ToL1Calls.length) revert UnconsumedCalls();
         if (_lastNestedActionConsumed != entry.expectedL1ToL2Calls.length) revert UnconsumedNestedActions();
+
+        // 7. Advance past entries[0] so follow-up `executeCrossChainCall`s don't re-consume it.
+        //    SYSTEM_ADDRESS is not reentry-reachable so no `_insideExecution()` guard is needed.
+        executionIndex = 1;
 
         emit EntryExecuted(0, _rollingHash, _currentCallNumber, _lastNestedActionConsumed);
         _currentCallNumber = 0; // reset so _insideExecution() returns false
@@ -240,20 +233,9 @@ contract EEZL2 is EEZBase {
 
     /// @notice Consumes the next nested action, or replays a pre-computed reverting
     ///         lookup call when no ExpectedL1ToL2Call matches.
-    /// @dev See L1 EEZ._consumeNestedAction for the full routing rules. L2 has no
-    ///      transient lookup-call table, so the fallback only scans persistent `lookupCalls`.
-    ///
-    ///      INTENTIONAL PARITY GAP with L1: L1's no-match arm sets a deferred-revert flag and
-    ///      returns empty bytes, so a caller's `try/catch` observes `(success=true, "")`. L2
-    ///      reverts immediately with `ExecutionNotFound`. The deferred path on L1 exists
-    ///      because L1 entries are prover-supplied via `postAndVerifyBatch` and the protocol
-    ///      wants the caller to observe a specific revert payload (via cached `LookupCall`)
-    ///      whose absence is a prover defect surfaced at the entry boundary. On L2 the
-    ///      execution table is loaded by `SYSTEM_ADDRESS` from already-finalized state — a
-    ///      no-match here means the system loaded a malformed table, which is not a recoverable
-    ///      case and SHOULD halt the entry immediately. Hence: post-increment commit (`++`
-    ///      above) is fine because every fall-through path reverts and the EVM rolls back the
-    ///      bump; no deferred flag and no `NestedActionNotFound` event are needed.
+    /// @dev L2 reverts immediately on no-match (no deferred-revert flag like L1). The
+    ///      system-loaded table is trusted, so a no-match is unrecoverable. The post-increment
+    ///      below is safe because every fall-through path reverts and rolls the bump back.
     function _consumeNestedAction(bytes32 crossChainCallHash) internal returns (bytes memory) {
         ExecutionEntry storage entry = executions[_currentEntryIndex];
         uint256 idx = _lastNestedActionConsumed++;

--- a/src/L2/EEZL2.sol
+++ b/src/L2/EEZL2.sol
@@ -31,6 +31,12 @@ contract EEZL2 is EEZBase {
     /// @notice Error when caller is not the system address
     error Unauthorized();
 
+    /// @notice Error when constructor is given the reserved mainnet rollup id (0)
+    error InvalidRollupId();
+
+    /// @notice Error when constructor is given the zero address for the system address
+    error InvalidSystemAddress();
+
     /// @notice Error when execution is attempted in a different block than the last load
     error ExecutionNotInCurrentBlock();
 
@@ -42,6 +48,11 @@ contract EEZL2 is EEZBase {
 
     /// @notice Error when `msg.value` attached to `executeIncomingCrossChainCall` doesn't match `value`
     error ValueMismatch();
+
+    /// @notice Error when the first entry's `proxyEntryHash` doesn't match the cross-chain
+    ///         call hash computed from the explicit (destination, value, data, sourceAddress,
+    ///         sourceRollup) params passed to `executeIncomingCrossChainCall`
+    error EntryHashMismatch();
 
     /// @notice Emitted when execution entries are loaded into the execution table
     event ExecutionTableLoaded(ExecutionEntry[] entries);
@@ -59,9 +70,14 @@ contract EEZL2 is EEZBase {
         uint256 sourceRollup
     );
 
-    /// @param _rollupId The rollup ID this L2 instance belongs to
+    /// @param _rollupId The rollup ID this L2 instance belongs to. MUST be non-zero — 0 is
+    ///        reserved as `MAINNET_ROLLUP_ID` on the L1 registry and is used as the
+    ///        `sourceRollupId` sentinel for L1-originated calls in the cross-chain call hash.
+    ///        An L2 deployed with id 0 would produce call hashes indistinguishable from
+    ///        mainnet-originated calls.
     /// @param _systemAddress The privileged address allowed to load execution tables
     constructor(uint256 _rollupId, address _systemAddress) {
+        if (_rollupId == 0) revert InvalidRollupId();
         ROLLUP_ID = _rollupId;
         SYSTEM_ADDRESS = _systemAddress;
     }
@@ -195,7 +211,15 @@ contract EEZL2 is EEZBase {
         //    expects (entry index 0, fresh rolling hash, call cursor at 0, nested cursor at 0).
         ExecutionEntry storage entry = executions[0];
 
-        // 4. Drive the flat call processor — `entry.L2ToL1Calls[0]` is the inbound call,
+        // 4. Bind the inbound call hash to the entry. The (destination, value, data,
+        //    sourceAddress, sourceRollup) tuple was emitted in the event above and folded
+        //    into `crossChainCallHash`; the entry's calls are baked into storage. Without
+        //    this check, SYSTEM_ADDRESS could emit one tuple while `_processNCalls` runs an
+        //    entirely different call sequence, leaving the emitted hash and the actual
+        //    execution divergent. Matches the equivalent check on L1's `_consumeAndExecute`.
+        if (entry.proxyEntryHash != crossChainCallHash) revert EntryHashMismatch();
+
+        // 5. Drive the flat call processor — `entry.L2ToL1Calls[0]` is the inbound call,
         //    delivered via the source proxy by `_processNCalls`
         _processNCalls(entry.callCount);
 
@@ -218,6 +242,18 @@ contract EEZL2 is EEZBase {
     ///         lookup call when no ExpectedL1ToL2Call matches.
     /// @dev See L1 EEZ._consumeNestedAction for the full routing rules. L2 has no
     ///      transient lookup-call table, so the fallback only scans persistent `lookupCalls`.
+    ///
+    ///      INTENTIONAL PARITY GAP with L1: L1's no-match arm sets a deferred-revert flag and
+    ///      returns empty bytes, so a caller's `try/catch` observes `(success=true, "")`. L2
+    ///      reverts immediately with `ExecutionNotFound`. The deferred path on L1 exists
+    ///      because L1 entries are prover-supplied via `postAndVerifyBatch` and the protocol
+    ///      wants the caller to observe a specific revert payload (via cached `LookupCall`)
+    ///      whose absence is a prover defect surfaced at the entry boundary. On L2 the
+    ///      execution table is loaded by `SYSTEM_ADDRESS` from already-finalized state — a
+    ///      no-match here means the system loaded a malformed table, which is not a recoverable
+    ///      case and SHOULD halt the entry immediately. Hence: post-increment commit (`++`
+    ///      above) is fine because every fall-through path reverts and the EVM rolls back the
+    ///      bump; no deferred flag and no `NestedActionNotFound` event are needed.
     function _consumeNestedAction(bytes32 crossChainCallHash) internal returns (bytes memory) {
         ExecutionEntry storage entry = executions[_currentEntryIndex];
         uint256 idx = _lastNestedActionConsumed++;

--- a/src/base/EEZBase.sol
+++ b/src/base/EEZBase.sol
@@ -128,6 +128,10 @@ abstract contract EEZBase is IEEZ {
     /// @notice Error when not all nested actions were consumed after execution
     error UnconsumedNestedActions();
 
+    /// @notice Error when a lookup-call sub-call targets an un-deployed proxy
+    /// @dev STATICCALL to a codeless address returns `(true, "")`; prover could pre-hash that.
+    error LookupCallProxyNotDeployed(address sourceProxy);
+
     /// @notice Error when not all calls were consumed after execution
     error UnconsumedCalls();
 
@@ -211,6 +215,8 @@ abstract contract EEZBase is IEEZ {
     // ──────────────────────────────────────────────
 
     /// @notice Decodes a `ContextResult` revert payload returned by `executeInContextAndRevert`.
+    /// @dev Validates selector AND length (4 + 4*32 = 132) before the raw mloads — defense
+    ///      against a truncated revert that happens to share the selector.
     function _decodeContextResult(bytes memory revertData)
         internal
         pure
@@ -219,6 +225,7 @@ abstract contract EEZBase is IEEZ {
         if (bytes4(revertData) != ContextResult.selector) {
             revert UnexpectedContextRevert(revertData);
         }
+        if (revertData.length < 132) revert UnexpectedContextRevert(revertData);
         assembly {
             let ptr := add(revertData, 36)
             rollingHash := mload(ptr)
@@ -269,6 +276,8 @@ abstract contract EEZBase is IEEZ {
         for (uint256 i = 0; i < calls.length; i++) {
             L2ToL1Call memory cc = calls[i];
             address sourceProxy = computeCrossChainProxyAddress(cc.sourceAddress, cc.sourceRollupId);
+            // STATICCALL to a codeless address silently succeeds — reject so the prover can't pre-hash a no-op.
+            if (sourceProxy.code.length == 0) revert LookupCallProxyNotDeployed(sourceProxy);
             (bool success, bytes memory retData) =
                 sourceProxy.staticcall(abi.encodeCall(CrossChainProxy.executeOnBehalf, (cc.targetAddress, cc.data)));
             computedHash = _rollingHashStaticResult(computedHash, success, retData);

--- a/src/periphery/defiMock/FlashLoanersNFT.sol
+++ b/src/periphery/defiMock/FlashLoanersNFT.sol
@@ -21,6 +21,6 @@ contract FlashLoanersNFT is ERC721 {
         require(token.balanceOf(msg.sender) >= MIN_BALANCE, "Balance too low");
 
         hasClaimed[msg.sender] = true;
-        _mint(msg.sender, nextTokenId++);
+        _mint(msg.sender, ++nextTokenId);
     }
 }

--- a/src/rollupContract/Rollup.sol
+++ b/src/rollupContract/Rollup.sol
@@ -29,8 +29,7 @@ contract Rollup is IRollupContract {
     ///      governance contract, or any other model.
     address public owner;
 
-    /// @notice The rollupId this contract manages. Written by the `rollupContractRegistered` callback,
-    ///         on registration (`EEZ.registerRollup`) or handoff (`EEZ.setRollupContract`).
+    /// @notice The rollupId this contract manages. Written once on registration.
     uint256 public rollupId;
 
     /// @notice Minimum number of proof systems that must attest per batch (M of N). Owner is
@@ -139,12 +138,8 @@ contract Rollup is IRollupContract {
         return (0, bytes32(0));
     }
 
-    /// @notice Notification fired by the central registry on first registration.
-    /// @dev Auth: caller MUST be the central `ROLLUPS` registry, otherwise `NotEEZRegistry`.
-    ///      One-shot: rejects subsequent calls with `AlreadyRegistered`. Since `EEZ.registerRollup`
-    ///      assigns rollupIds starting at 1, `rollupId == 0` is the canonical "not yet registered"
-    ///      sentinel. Without this, a permissionless second `registerRollup(thisManager, ...)`
-    ///      would clobber `rollupId` and brick the original rollup's setStateRoot escape hatch.
+    /// @notice One-shot registration callback fired by the central registry.
+    /// @dev `rollupId == 0` is the unset sentinel (registry assigns ids starting at 1).
     function rollupContractRegistered(uint256 _rollupId) external {
         if (msg.sender != ROLLUPS) revert NotEEZRegistry();
         if (rollupId != 0) revert AlreadyRegistered();

--- a/src/rollupContract/Rollup.sol
+++ b/src/rollupContract/Rollup.sol
@@ -53,6 +53,7 @@ contract Rollup is IRollupContract {
     error NotOwner();
     error NotEEZRegistry();
     error InvalidConfig();
+    error AlreadyRegistered();
     error ProofSystemAlreadyAllowed(address proofSystem);
     error ProofSystemNotAllowed(address proofSystem);
 
@@ -140,11 +141,13 @@ contract Rollup is IRollupContract {
 
     /// @notice Notification fired by the central registry on first registration.
     /// @dev Auth: caller MUST be the central `ROLLUPS` registry, otherwise `NotEEZRegistry`.
-    ///      This impl does NOT enforce one-shot semantics — overwriting `rollupId` is allowed,
-    ///      though the registry no longer exposes a manager-handoff path so this should fire
-    ///      exactly once in normal operation.
+    ///      One-shot: rejects subsequent calls with `AlreadyRegistered`. Since `EEZ.registerRollup`
+    ///      assigns rollupIds starting at 1, `rollupId == 0` is the canonical "not yet registered"
+    ///      sentinel. Without this, a permissionless second `registerRollup(thisManager, ...)`
+    ///      would clobber `rollupId` and brick the original rollup's setStateRoot escape hatch.
     function rollupContractRegistered(uint256 _rollupId) external {
         if (msg.sender != ROLLUPS) revert NotEEZRegistry();
+        if (rollupId != 0) revert AlreadyRegistered();
         rollupId = _rollupId;
     }
 

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -66,16 +66,6 @@ abstract contract Base is Test {
     function setUpBase() internal {
         rollups = new EEZ();
         ps = new MockProofSystem();
-
-        // Burn rollupId 0 (MAINNET_ROLLUP_ID): the strict-increasing rollupIds check in
-        // postAndVerifyBatch rejects rid <= prevRid where prevRid starts at MAINNET_ROLLUP_ID (0).
-        // So id 0 is unpostable. Register a throwaway rollup first so user rollups land at id >= 1.
-        address[] memory psList = new address[](1);
-        psList[0] = address(ps);
-        bytes32[] memory vks = new bytes32[](1);
-        vks[0] = DEFAULT_VK;
-        Rollup burn = new Rollup(address(rollups), defaultOwner, 1, psList, vks);
-        rollups.registerRollup(address(burn), bytes32(0));
     }
 
     // ──────────────────────────────────────────────

--- a/test/EEZ.t.sol
+++ b/test/EEZ.t.sol
@@ -170,8 +170,8 @@ contract EEZTest is Base {
     function test_CreateRollup() public {
         bytes32 initialState = keccak256("initial");
         (uint256 rid, Rollup r) = _makeRollupLocal(initialState, alice);
-        // rid 0 is burned by setUpBase (MAINNET_ROLLUP_ID is unpostable), so the first
-        // user-registered rollup lands at id 1.
+        // registerRollup pre-increments rollupCounter, so id 0 (MAINNET_ROLLUP_ID) is
+        // skipped and the first user-registered rollup lands at id 1.
         assertEq(rid, 1);
         assertEq(_getRollupState(rid), initialState);
         assertEq(_getRollupContract(rid), address(r));
@@ -741,7 +741,7 @@ contract EEZTest is Base {
         vks[0] = DEFAULT_VK;
         Rollup r = new Rollup(address(rollups), alice, 1, psList, vks);
         vm.expectEmit(true, true, true, true);
-        // rid 0 was burned in setUpBase, so this fresh rollup lands at id 1.
+        // registerRollup skips id 0 (MAINNET_ROLLUP_ID), so this fresh rollup lands at id 1.
         emit EEZ.RollupCreated(1, address(r), keccak256("init"));
         rollups.registerRollup(address(r), keccak256("init"));
     }

--- a/test/IntegrationTest.t.sol
+++ b/test/IntegrationTest.t.sol
@@ -77,18 +77,8 @@ contract IntegrationTest is Test {
         rollups = new EEZ();
         ps = new MockProofSystem();
 
-        // The contract has no `startingRollupId` constructor arg, so `rollupCounter`
-        // starts at 0 and the FIRST registered rollup would receive id 0 = MAINNET.
-        // postAndVerifyBatch validation rejects id 0 (strict-increasing from MAINNET_ROLLUP_ID),
-        // so we burn id 0 with a throwaway rollup, then register L2 at id 1.
-        {
-            address[] memory psList = new address[](1);
-            psList[0] = address(ps);
-            bytes32[] memory vks = new bytes32[](1);
-            vks[0] = DEFAULT_VK;
-            Rollup burnRollup = new Rollup(address(rollups), address(this), 1, psList, vks);
-            rollups.registerRollup(address(burnRollup), bytes32(0));
-        }
+        // registerRollup pre-increments rollupCounter, so id 0 (MAINNET_ROLLUP_ID) is
+        // skipped and the first registered rollup lands at id 1 = L2_ROLLUP_ID.
 
         // Create L2 rollup at id = 1 = L2_ROLLUP_ID
         {

--- a/test/IntegrationTestBridge.t.sol
+++ b/test/IntegrationTestBridge.t.sol
@@ -80,15 +80,8 @@ contract IntegrationTestBridge is Test {
         rollups = new EEZ();
         ps = new MockProofSystem();
 
-        // Burn rollupId 0 = MAINNET so the L2 rollup gets id 1.
-        {
-            address[] memory psList = new address[](1);
-            psList[0] = address(ps);
-            bytes32[] memory vks = new bytes32[](1);
-            vks[0] = DEFAULT_VK;
-            Rollup burnRollup = new Rollup(address(rollups), address(this), 1, psList, vks);
-            rollups.registerRollup(address(burnRollup), bytes32(0));
-        }
+        // registerRollup skips id 0 (MAINNET_ROLLUP_ID), so the first registered rollup
+        // lands at id 1 = L2_ROLLUP_ID.
         {
             address[] memory psList = new address[](1);
             psList[0] = address(ps);

--- a/test/IntegrationTestFlashLoan.t.sol
+++ b/test/IntegrationTestFlashLoan.t.sol
@@ -104,15 +104,8 @@ contract IntegrationTestFlashLoan is Test {
         rollups = new EEZ();
         ps = new MockProofSystem();
 
-        // Burn rollupId 0 = MAINNET so the L2 rollup gets id 1.
-        {
-            address[] memory psList = new address[](1);
-            psList[0] = address(ps);
-            bytes32[] memory vks = new bytes32[](1);
-            vks[0] = DEFAULT_VK;
-            Rollup burnRollup = new Rollup(address(rollups), address(this), 1, psList, vks);
-            rollups.registerRollup(address(burnRollup), bytes32(0));
-        }
+        // registerRollup skips id 0 (MAINNET_ROLLUP_ID), so the first registered rollup
+        // lands at id 1 = L2_ROLLUP_ID.
         {
             address[] memory psList = new address[](1);
             psList[0] = address(ps);


### PR DESCRIPTION
## Summary

- **`EEZ.registerRollup`**: switched from post-increment to pre-increment on `rollupCounter`, so id 0 (`MAINNET_ROLLUP_ID`) is now permanently skipped and the first registered rollup lands at id 1. Removes the need for the "burn rollup 0" dance from every deploy script and test fixture.
- **`Rollup.rollupContractRegistered`**: now one-shot — reverts `AlreadyRegistered` on a second call. Without this, a permissionless re-registration could clobber a manager's `rollupId` and brick its `setStateRoot` escape hatch.
- **`EEZL2` constructor**: rejects `_rollupId == 0` with `InvalidRollupId`. An L2 deployed with id 0 would produce call hashes indistinguishable from mainnet-originated calls.
- **`EEZL2.executeIncomingCrossChainCall`**: binds the inbound call to the entry by checking `entry.proxyEntryHash == crossChainCallHash`, matching L1's `_consumeAndExecute`. Closes a gap where `SYSTEM_ADDRESS` could emit one tuple while `_processNCalls` executed a different sequence.
- **`EEZ._consumeNestedAction`**: emits new `NestedActionNotFound` event on the deferred-no-match path. The eventual `ExecutionNotFound` surfaces at the entry boundary, not at the offending reentrant call, so this event makes the divergence point legible from off-chain traces.
- **`EEZL2._consumeNestedAction`**: documented the intentional parity gap with L1 — L2 reverts immediately on no-match (system-loaded table, not prover-supplied, so no deferred-revert payload is meaningful).