### PR TITLE
Reduce CrossChainProxy deployment gas with minimal clones

### DIFF
--- a/src/base/CrossChainProxy.sol
+++ b/src/base/CrossChainProxy.sol
@@ -25,12 +25,19 @@ contract CrossChainProxy {
     /// @param _eez The EEZ manager contract address (`EEZ` on L1, `EEZL2` on L2)
     constructor(address _eez) {
         EEZ = _eez;
+    }
 
-        // Best-effort sweep of ether sent here before deployment (otherwise stuck —
-        // the proxy only forwards msg.value); a failed transfer never blocks creation.
-        uint256 predeployedEther = address(this).balance;
-        if (predeployedEther != 0) {
-            IEEZ(_eez).RECOVERY_ADDRESS().call{value: predeployedEther}("");
+    /// @notice Best-effort recovery of ETH sent to a deterministic proxy address
+    ///         before the clone was deployed.
+    /// @dev Clone construction does not execute this implementation's constructor,
+    ///      so the manager invokes this immediately after clone deployment when the
+    ///      predicted address already has a balance.
+    function sweepPredeployedEther() external {
+        if (msg.sender != EEZ) {
+            _fallback();
+        } else {
+            (bool recovered,) = IEEZ(EEZ).RECOVERY_ADDRESS().call{value: address(this).balance}("");
+            recovered; // Best effort: recovery failure must not block clone creation.
         }
     }
 

--- a/src/base/EEZBase.sol
+++ b/src/base/EEZBase.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IEEZ, ProxyInfo, StateUpdate} from "../interfaces/IEEZ.sol";
 import {CrossChainProxy} from "./CrossChainProxy.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 /// @title EEZBase
 /// @notice Direction-neutral shared base for the L1 (`EEZ`) and L2 (`EEZL2`) cross-chain managers.
@@ -33,6 +34,15 @@ import {CrossChainProxy} from "./CrossChainProxy.sol";
 ///        - The per-side events and errors (L1: `EntryExecuted`, `CallResult`, …;
 ///          L2: `EntryExecuted`, `CallResult`, …).
 abstract contract EEZBase is IEEZ {
+    /// @notice Shared implementation used by every deterministic CrossChainProxy clone.
+    /// @dev The implementation embeds this manager as an immutable, while delegatecall
+    ///      preserves each clone's address, balance, transient storage and caller identity.
+    address public immutable CROSS_CHAIN_PROXY_IMPLEMENTATION;
+
+    constructor() {
+        CROSS_CHAIN_PROXY_IMPLEMENTATION = address(new CrossChainProxy(address(this)));
+    }
+
     // ──────────────────────────────────────────────
     //  Rolling-hash tag constants
     // ──────────────────────────────────────────────
@@ -157,31 +167,39 @@ abstract contract EEZBase is IEEZ {
         return _createCrossChainProxyInternal(originalAddress, originalRollupId);
     }
 
-    /// @notice Deploys a CrossChainProxy via CREATE2 and registers it as authorized
-    function _createCrossChainProxyInternal(address originalAddress, uint64 originalRollupId)
+    /// @notice Deploys a minimal CrossChainProxy clone via CREATE2 and registers it as authorized
+    function _createCrossChainProxyInternal(
+        address originalAddress,
+        uint64 originalRollupId
+    )
         internal
         returns (address proxy)
     {
         // A proxy stands in for a REMOTE address — never one on this manager's own network.
         if (originalRollupId == _getRollupId()) revert SameNetworkProxy(originalRollupId);
         bytes32 salt = keccak256(abi.encodePacked(originalRollupId, originalAddress));
-        proxy = address(new CrossChainProxy{salt: salt}(address(this)));
+        proxy = Clones.cloneDeterministic(CROSS_CHAIN_PROXY_IMPLEMENTATION, salt);
         authorizedProxies[proxy] = ProxyInfo(true, originalAddress, originalRollupId);
         emit CrossChainProxyCreated(proxy, originalAddress, originalRollupId);
+
+        // Preserve the old full-contract constructor's recovery behavior. A failed
+        // recovery transfer remains best-effort and never blocks proxy creation.
+        if (proxy.balance != 0) CrossChainProxy(payable(proxy)).sweepPredeployedEther();
     }
 
     /// @notice Computes the deterministic CREATE2 address for a CrossChainProxy
     /// @param originalAddress The address this proxy represents on the source rollup
     /// @param originalRollupId The source rollup ID
-    function computeCrossChainProxyAddress(address originalAddress, uint64 originalRollupId)
+    function computeCrossChainProxyAddress(
+        address originalAddress,
+        uint64 originalRollupId
+    )
         public
         view
         returns (address)
     {
         bytes32 salt = keccak256(abi.encodePacked(originalRollupId, originalAddress));
-        bytes32 bytecodeHash =
-            keccak256(abi.encodePacked(type(CrossChainProxy).creationCode, abi.encode(address(this))));
-        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, bytecodeHash)))));
+        return Clones.predictDeterministicAddress(CROSS_CHAIN_PROXY_IMPLEMENTATION, salt, address(this));
     }
 
     // ──────────────────────────────────────────────

--- a/test/EEZL2.t.sol
+++ b/test/EEZL2.t.sol
@@ -148,6 +148,16 @@ contract EEZL2Test is BaseL2 {
         assertTrue(codeSize > 0);
     }
 
+    function test_CreateCrossChainProxy_UsesMinimalCloneAndCostsUnder100kGas() public {
+        uint256 gasBefore = gasleft();
+        address proxy = manager.createCrossChainProxy(address(target), REMOTE_ROLLUP_ID);
+        uint256 gasUsed = gasBefore - gasleft();
+
+        assertEq(proxy.code.length, 45, "EIP-1167 runtime must remain minimal");
+        assertGt(manager.CROSS_CHAIN_PROXY_IMPLEMENTATION().code.length, proxy.code.length);
+        assertLt(gasUsed, 100_000, "proxy creation gas regression");
+    }
+
     function test_CreateCrossChainProxy_EmitsEvent() public {
         vm.expectEmit(true, true, true, true);
         emit EEZBase.CrossChainProxyCreated(


### PR DESCRIPTION
Closes #38

## Summary
- deploy one immutable `CrossChainProxy` implementation per EEZ manager
- deploy deterministic EIP-1167 clones for remote identities
- preserve recovery of ETH sent to a predicted proxy address before deployment
- add a regression test locking the clone runtime to 45 bytes and creation gas below 100,000

## Gas impact
- existing full proxy deployment observed on the live network: 280,496 gas
- new proxy creation test: 79,275 gas (including the test call path)
- tradeoff: one implementation deployment per manager and a small delegatecall overhead per proxy call

Proxy addresses are derived from the clone init-code hash, so this changes predicted proxy addresses for newly deployed managers.

## Tests
- `forge test --match-path test/EEZ.t.sol -q`
- `forge test --match-path test/EEZL2.t.sol -q`
- `forge test --match-path test/IntegrationTestBridge.t.sol -q`